### PR TITLE
Add possibility to control the navigation flavor (window, expand)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ in progress
 - Modernize to Python 3
 - Add compatibility with Grafana 6, 7 and 8
 - Add possibility to login to protected Grafana instances
+- Add possibility to control the navigation flavor (window, expand)
 
 
 2019-02-04 0.5.5

--- a/doc/backlog.rst
+++ b/doc/backlog.rst
@@ -8,7 +8,7 @@ Prio 1
 ******
 - [x] Modernize to Python 3 and Grafana 7/8
 - [x] Add possibility to authenticate with Grafana
-- [o] Add parameter to toggle between flavor = 'window|expand' in ``animations.py``
+- [x] Add parameter to toggle between flavor = 'window|expand' in ``animations.py``
 - [o] Standalone scenario recipes. TOML?
 - [o] Clear Javascript event handlers after usage, maybe using ``scope.$on('$destroy', ...)``
 - [o] Avoid collisions in output directory, e.g. take ``flavor`` into account

--- a/grafanimate/animations.py
+++ b/grafanimate/animations.py
@@ -10,6 +10,7 @@ from dateutil.relativedelta import relativedelta
 from dateutil.rrule import rrule, SECONDLY, MINUTELY, HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY
 
 from grafanimate.grafana import GrafanaWrapper
+from grafanimate.model import NavigationFlavor
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +32,7 @@ class SequentialAnimation:
         logger.info(message)
         self.grafana.console_info(message)
 
-    def run(self, dtstart=None, dtuntil=None, interval=None):
+    def run(self, dtstart=None, dtuntil=None, interval=None, flavor: NavigationFlavor = NavigationFlavor.WINDOW):
 
         self.log("Animation started")
 
@@ -39,13 +40,10 @@ class SequentialAnimation:
             message = 'Timestamp dtstart={} is after dtuntil={}'.format(dtstart, dtuntil)
             raise ValueError(message)
 
-        #flavor = 'expand'
-        flavor = 'window'
-
         rr_freq, rr_interval, dtdelta = self.get_freq_delta(interval)
 
         #until = datetime.now()
-        if flavor == 'expand':
+        if flavor == NavigationFlavor.EXPAND:
             dtuntil += dtdelta
 
         # Compute complete date range.
@@ -61,11 +59,11 @@ class SequentialAnimation:
 
             # Compute start and end dates based on flavor.
 
-            if flavor == 'window':
+            if flavor == NavigationFlavor.WINDOW:
                 dtstart = date
                 dtuntil = date + dtdelta
 
-            elif flavor == 'expand':
+            elif flavor == NavigationFlavor.EXPAND:
                 dtuntil = date
 
             # Render image.

--- a/grafanimate/model.py
+++ b/grafanimate/model.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class NavigationFlavor(Enum):
+    WINDOW = "window"
+    EXPAND = "expand"

--- a/grafanimate/scenarios.py
+++ b/grafanimate/scenarios.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 from grafanimate.animations import SequentialAnimation
 from grafanimate.grafana import GrafanaWrapper
+from grafanimate.model import NavigationFlavor
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +17,12 @@ class AnimationScenario:
 
     As the ad-hoc interface is not finished yet,
     this is all we got. Enjoy!
+
+    The parameters `dtstart`, `dtuntil` and `interval` should explain themselves.
+
+    The parameter `flavor` can has two values (defaulting to `window`):
+    - "window" will slide a window through the defined time range
+    - "expand" will use a fixed start time and stepwise expand the end time
     """
 
     def __init__(self, grafana: GrafanaWrapper, storage, dashboard_uid=None, target=None, options=None):
@@ -42,8 +49,7 @@ class AnimationScenario:
         """
         logger.info('Running scenario playdemo')
 
-        results = self.engine.run(dtstart=datetime(2021, 11, 14, 2, 0, 0), dtuntil=datetime(2021, 11, 14, 4, 16, 36), interval='5min')
-        #results = self.engine.run(dtstart=datetime(2021, 11, 14, 2, 0, 0), dtuntil=datetime(2021, 11, 14, 2, 16, 36), interval='5min')
+        results = self.engine.run(dtstart=datetime(2021, 11, 14, 2, 0, 0), dtuntil=datetime(2021, 11, 14, 4, 16, 36), interval='5min', flavor=NavigationFlavor.EXPAND)
         self.storage.save_items(results)
 
     def ldi_all(self):


### PR DESCRIPTION
The new scenario parameter `flavor` can has two values:
- "window" will slide a window through the defined time range
- "expand" will use a fixed start time and stepwise expand the end time

While `window` was hardcoded beforehand, you can now also use `expand`. It is a suitable flavor when aiming to demonstrate the progress of a timeseries starting at a fixed point in time.

Example:
```
grafanimate --grafana-url=https://play.grafana.org/ --dashboard-uid=000000012 --scenario=playdemo
```

/cc @wetterfrosch 