### PR TITLE
Introduce a data model for defining animation-scenarios and -sequences

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ in progress
 - Add possibility to login to protected Grafana instances
 - Add possibility to control the navigation flavor (window, expand)
 - Introduce data model for animation scenarios
+- Allow loading scenarios from arbitrary Python modules and files
 
 
 2019-02-04 0.5.5

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ in progress
 - Add compatibility with Grafana 6, 7 and 8
 - Add possibility to login to protected Grafana instances
 - Add possibility to control the navigation flavor (window, expand)
+- Introduce data model for animation scenarios
 
 
 2019-02-04 0.5.5

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ in progress
 - Add possibility to control the navigation flavor (window, expand)
 - Introduce data model for animation scenarios
 - Allow loading scenarios from arbitrary Python modules and files
+- Optionally define ``grafana_url`` and ``dashboard_uid`` within scenario file.
+  Corresponding command line parameters ``--grafana-url`` and ``--dashboard-uid``
+  still take preference.
 
 
 2019-02-04 0.5.5

--- a/README.rst
+++ b/README.rst
@@ -97,8 +97,17 @@ Usage
       --grafana-url=<url>           Base URL to Grafana, [default: http://localhost:3000].
                                     If your Grafana instance is protected, please specify credentials
                                     within the URL, e.g. https://user:pass@www.example.org/grafana.
-      --scenario=<scenario>         Which scenario to run. Scenarios are defined as methods within the
-                                    `scenarios.py` file.
+
+      --scenario=<scenario>         Which scenario to run. Built-in scenarios are defined within the
+                                    `scenarios.py` file, however you can easily define scenarios in
+                                    custom Python files.
+
+                                    Scenarios can be referenced by arbitrary entrypoints, like:
+
+                                    - ``--scenario=grafanimate.scenarios:playdemo``    (module, symbol)
+                                    - ``--scenario=grafanimate/scenarios.py:playdemo`` (file, symbol)
+                                    - ``--scenario=playdemo`` (built-in)
+
       --dashboard-uid=<uid>         Grafana dashboard uid.
 
     Optional:

--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ Usage
       grafanimate (-h | --help)
 
     Options:
-      --grafana-url=<url>           Base URL to Grafana, [default: http://localhost:3000].
+      --grafana-url=<url>           Base URL to Grafana.
                                     If your Grafana instance is protected, please specify credentials
                                     within the URL, e.g. https://user:pass@www.example.org/grafana.
 

--- a/doc/backlog.rst
+++ b/doc/backlog.rst
@@ -11,6 +11,7 @@ Prio 1
 - [x] Add parameter to toggle between flavor = 'window|expand' in ``animations.py``
 - [x] Standalone scenario recipes. TOML?
 - [x] Load scenarios from arbitrary modules and files.
+- [x] Optionally use ``url`` from scenario
 - [o] Clear Javascript event handlers after usage, maybe using ``scope.$on('$destroy', ...)``
 - [o] Avoid collisions in output directory, e.g. take ``flavor`` into account
 

--- a/doc/backlog.rst
+++ b/doc/backlog.rst
@@ -9,7 +9,8 @@ Prio 1
 - [x] Modernize to Python 3 and Grafana 7/8
 - [x] Add possibility to authenticate with Grafana
 - [x] Add parameter to toggle between flavor = 'window|expand' in ``animations.py``
-- [o] Standalone scenario recipes. TOML?
+- [x] Standalone scenario recipes. TOML?
+- [x] Load scenarios from arbitrary modules and files.
 - [o] Clear Javascript event handlers after usage, maybe using ``scope.$on('$destroy', ...)``
 - [o] Avoid collisions in output directory, e.g. take ``flavor`` into account
 

--- a/grafanimate/animations.py
+++ b/grafanimate/animations.py
@@ -3,6 +3,7 @@
 # License: GNU Affero General Public License, Version 3
 import logging
 import time
+from operator import attrgetter
 
 from munch import munchify
 from datetime import timedelta
@@ -10,7 +11,7 @@ from dateutil.relativedelta import relativedelta
 from dateutil.rrule import rrule, SECONDLY, MINUTELY, HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY
 
 from grafanimate.grafana import GrafanaWrapper
-from grafanimate.model import NavigationFlavor
+from grafanimate.model import NavigationFlavor, AnimationStep
 
 logger = logging.getLogger(__name__)
 
@@ -32,9 +33,12 @@ class SequentialAnimation:
         logger.info(message)
         self.grafana.console_info(message)
 
-    def run(self, dtstart=None, dtuntil=None, interval=None, flavor: NavigationFlavor = NavigationFlavor.WINDOW):
+    def run(self, step: AnimationStep):
 
         self.log("Animation started")
+
+        # Destructure `step` instance.
+        dtstart, dtuntil, interval, flavor = attrgetter("dtstart", "dtuntil", "interval", "flavor")(step)
 
         if dtstart > dtuntil:
             message = 'Timestamp dtstart={} is after dtuntil={}'.format(dtstart, dtuntil)

--- a/grafanimate/commands.py
+++ b/grafanimate/commands.py
@@ -22,8 +22,17 @@ def run():
       --grafana-url=<url>           Base URL to Grafana, [default: http://localhost:3000].
                                     If your Grafana instance is protected, please specify credentials
                                     within the URL, e.g. https://user:pass@www.example.org/grafana.
-      --scenario=<scenario>         Which scenario to run. Scenarios are defined as methods within the
-                                    `scenarios.py` file.
+
+      --scenario=<scenario>         Which scenario to run. Built-in scenarios are defined within the
+                                    `scenarios.py` file, however you can easily define scenarios in
+                                    custom Python files.
+
+                                    Scenarios can be referenced by arbitrary entrypoints, like:
+
+                                    - ``--scenario=grafanimate.scenarios:playdemo``    (module, symbol)
+                                    - ``--scenario=grafanimate/scenarios.py:playdemo`` (file, symbol)
+                                    - ``--scenario=playdemo`` (built-in)
+
       --dashboard-uid=<uid>         Grafana dashboard uid.
 
     Optional:

--- a/grafanimate/grafana.py
+++ b/grafanimate/grafana.py
@@ -187,7 +187,7 @@ class GrafanaWrapper(FirefoxMarionetteBase):
         Wait for map element <panel-plugin-grafana-worldmap-panel ...> to appear.
         """
         log.debug('Waiting for map element to appear in DOM')
-        # TODO: Make naming more universal.
+        # TODO: Make naming/addressing more universal.
         element = self.wait_for_element_tag("panel-plugin-grafana-worldmap-panel")
         log.info('Finished waiting for map element')
         log.info(element)

--- a/grafanimate/mediastorage.py
+++ b/grafanimate/mediastorage.py
@@ -28,7 +28,7 @@ class MediaStorage:
 
         # Compute image sequence file name.
         imagefile = self.imagefile_template.format(
-            scenario=item.meta.scenario,
+            scenario=slug(item.meta.scenario),
             interval=item.meta.interval,
             uid=item.meta.dashboard,
             dtstart=format_date_human(item.data.dtstart),
@@ -44,12 +44,13 @@ class MediaStorage:
 
         logger.info('Saved frame to {}. Size: {}'.format(imagefile, len(item.data.image)))
 
-    def produce_artifacts(self, path, uid=None, name=None):
+    def produce_artifacts(self, path, scenario=None, uid=None, name=None):
         # TODO: Can use dashboard title as output filename here?
         # TODO: Can put dtstart into filename?
 
         #uid = self.dashboard_uid
         name = name or uid
+        scenario = slug(scenario.replace(".py", ""))
 
         # Compute path to sequence images.
         #imagefile_pattern = self.imagefile_template.format(uid=uid, dtstart='*', dtuntil='*')
@@ -58,7 +59,7 @@ class MediaStorage:
         # Compute output file name.
         if name:
             name = slug(name)
-        outputfile = self.outputfile_template.format(name=name, uid=uid)
+        outputfile = self.outputfile_template.format(scenario=scenario, name=name, uid=uid)
 
         # Produce output artifacts.
         ensure_directory(outputfile)

--- a/grafanimate/model.py
+++ b/grafanimate/model.py
@@ -23,4 +23,5 @@ class AnimationStep:
 @dataclasses.dataclass
 class AnimationScenario:
     steps: List[AnimationStep]
+    grafana_url: Optional[str] = None
     dashboard_uid: Optional[str] = None

--- a/grafanimate/model.py
+++ b/grafanimate/model.py
@@ -1,6 +1,26 @@
+# -*- coding: utf-8 -*-
+# (c) 2021 Andreas Motl <andreas.motl@panodata.org>
+# License: GNU Affero General Public License, Version 3
+import dataclasses
+from datetime import datetime
 from enum import Enum
+from typing import List, Optional
 
 
 class NavigationFlavor(Enum):
     WINDOW = "window"
     EXPAND = "expand"
+
+
+@dataclasses.dataclass
+class AnimationStep:
+    dtstart: datetime
+    dtuntil: datetime
+    interval: str
+    flavor: Optional[NavigationFlavor] = NavigationFlavor.WINDOW
+
+
+@dataclasses.dataclass
+class AnimationScenario:
+    steps: List[AnimationStep]
+    dashboard_uid: Optional[str] = None

--- a/grafanimate/postprocessing.py
+++ b/grafanimate/postprocessing.py
@@ -19,6 +19,7 @@ def to_video(source, target):
     # -vf "fps=25,format=yuv420p,drawtext=fontfile=OpenSans-Regular.ttf:text='Title of this Video':fontcolor=white:fontsize=24:x=(w-tw)/2:y=(h/PHI)+th
     #command = "ffmpeg -framerate 4 -pattern_type glob -i '{}' -c:v libx264 -vf 'fps=25,format=yuv420p,drawtext=text=Produced with Grafana and grafanimate:fontsize=11:x=w-tw-30:y=h-th-10:fontcolor=lightgrey:fontfile=/Library/Fonts/Arial.ttf' '{}' -y".format(source, target)
 
+    # TODO: Expose `-framerate` and `fps` values.
     command = "ffmpeg -framerate 2 -pattern_type glob -i '{}' -c:v libx264 -vf 'fps=25,format=yuv420p' '{}' -y".format(source, target)
     logger.info('Rendering video: {}'.format(target))
     logger.debug(command)
@@ -70,6 +71,7 @@ def to_gif(source, target):
     ffmpeg -i dwd-cdc-2018-08.mov -filter_complex 'fps=10,scale=480:-1:flags=lanczos,split [o1] [o2];[o1] palettegen [p]; [o2] fifo [o3];[o3] [p] paletteuse' dwd-cdc-2018-08-v2.gif -y
     """
 
+    # TODO: Expose `fps` and `scale` values.
     command = "ffmpeg -i '{}' -filter_complex 'fps=10,scale=480:-1:flags=lanczos,split [o1] [o2];[o1] palettegen [p]; [o2] fifo [o3];[o3] [p] paletteuse' '{}' -y".format(source, target)
     logger.info('Rendering GIF: {}'.format(target))
     logger.debug(command)

--- a/grafanimate/scenarios.py
+++ b/grafanimate/scenarios.py
@@ -1,17 +1,15 @@
 #  -*- coding: utf-8 -*-
-# (c) 2018 Andreas Motl <andreas@hiveeyes.org>
+# (c) 2018-2021 Andreas Motl <andreas@hiveeyes.org>
 # License: GNU Affero General Public License, Version 3
 import logging
 from datetime import datetime
 
-from grafanimate.animations import SequentialAnimation
-from grafanimate.grafana import GrafanaWrapper
-from grafanimate.model import NavigationFlavor
+from grafanimate.model import NavigationFlavor, AnimationStep
 
 logger = logging.getLogger(__name__)
 
 
-class AnimationScenario:
+class BuiltinScenarios:
     """
     Run different animation scenarios/sequences.
 
@@ -25,20 +23,6 @@ class AnimationScenario:
     - "expand" will use a fixed start time and stepwise expand the end time
     """
 
-    def __init__(self, grafana: GrafanaWrapper, storage, dashboard_uid=None, target=None, options=None):
-
-        self.grafana = grafana
-        self.storage = storage
-        self.dashboard_uid = dashboard_uid
-
-        # Dispatch output to different target formats.
-        # FIXME: Not implemented yet.
-        self.target = target
-
-        # Start the engines.
-        self.engine = SequentialAnimation(grafana=grafana, dashboard_uid=dashboard_uid, options=options)
-        self.engine.start()
-
     def playdemo(self):
         """
         Run demo on `play.grafana.org`.
@@ -48,80 +32,79 @@ class AnimationScenario:
             grafanimate --grafana-url=https://play.grafana.org/ --dashboard-uid=000000012 --scenario=playdemo
         """
         logger.info('Running scenario playdemo')
-
-        results = self.engine.run(dtstart=datetime(2021, 11, 14, 2, 0, 0), dtuntil=datetime(2021, 11, 14, 4, 16, 36), interval='5min', flavor=NavigationFlavor.EXPAND)
-        self.storage.save_items(results)
+        return AnimationStep(dtstart=datetime(2021, 11, 14, 2, 0, 0), dtuntil=datetime(2021, 11, 14, 4, 16, 36), interval='5min', flavor=NavigationFlavor.EXPAND)
 
     def ldi_all(self):
+        """
+        Luftdaten.info, all
+        """
         logger.info('Running scenario ldi_all')
 
-        # LDI, ramp-up
-        results = self.engine.run(dtstart=datetime(2015, 10, 1), dtuntil=datetime(2017, 1, 1), interval='monthly')
-        self.storage.save_items(results)
+        return [
 
-        # LDI, growth
-        results = self.engine.run(dtstart=datetime(2017, 1, 1), dtuntil=datetime.now(), interval='weekly')
-        self.storage.save_items(results)
+            # LDI, ramp-up
+            AnimationStep(dtstart=datetime(2015, 10, 1), dtuntil=datetime(2017, 1, 1), interval='monthly'),
+
+            # LDI, growth
+            AnimationStep(dtstart=datetime(2017, 1, 1), dtuntil=datetime.now(), interval='weekly'),
+
+        ]
 
     def ldi_with_gaps(self):
+        """
+        Luftdaten.info, growth
+        """
         logger.info('Running scenario ldi_with_gaps')
 
-        # LDI, ramp-up
-        results = self.engine.run(dtstart=datetime(2015, 10, 1), dtuntil=datetime(2017, 1, 1), interval='monthly')
-        self.storage.save_items(results)
+        return [
 
-        # LDI, growth, with gap at 2018-04-29 - 2018-12-20
-        # TODO: Detect empty data from datasource through Grafana Sidecar and skip respective images.
-        results = self.engine.run(dtstart=datetime(2017, 1, 1), dtuntil=datetime(2018, 6, 5), interval='weekly')
-        self.storage.save_items(results)
+            # LDI, ramp-up
+            AnimationStep(dtstart=datetime(2015, 10, 1), dtuntil=datetime(2017, 1, 1), interval='monthly'),
 
-        results = self.engine.run(dtstart=datetime(2018, 12, 20), dtuntil=datetime.now(), interval='weekly')
-        self.storage.save_items(results)
+            # LDI, growth, with gap at 2018-04-29 - 2018-12-20
+            # TODO: Detect empty data from datasource through Grafana Sidecar and skip respective images.
+            AnimationStep(dtstart=datetime(2017, 1, 1), dtuntil=datetime(2018, 6, 5), interval='weekly'),
+
+            # LDI, until now
+            AnimationStep(dtstart=datetime(2018, 12, 20), dtuntil=datetime.now(), interval='weekly'),
+        ]
 
     def ldi_nye_2017_2018(self):
+        """
+        LDI, New Year's Eve 2018
+        """
         logger.info('Running scenario ldi_nye_2017_2018')
-
-        # LDI, New Year's Eve 2018
-        results = self.engine.run(dtstart=datetime(2017, 12, 31, 21, 0, 0), dtuntil=datetime(2018, 1, 1, 4, 0, 0), interval='10min')
-        self.storage.save_items(results)
+        return AnimationStep(dtstart=datetime(2017, 12, 31, 21, 0, 0), dtuntil=datetime(2018, 1, 1, 4, 0, 0), interval='10min')
 
     def ldi_nye_2018_2019(self):
+        """
+        LDI, New Year's Eve 2018/2019
+        """
         logger.info('Running scenario ldi_nye_2018_2019')
-
-        # LDI, New Year's Eve 2018/2019
-        results = self.engine.run(dtstart=datetime(2018, 12, 31, 15, 0, 0), dtuntil=datetime(2018, 12, 31, 20, 0, 0), interval='30min')
-        self.storage.save_items(results)
-
-        results = self.engine.run(dtstart=datetime(2018, 12, 31, 20, 0, 0), dtuntil=datetime(2018, 12, 31, 23, 0, 0), interval='10min')
-        self.storage.save_items(results)
-
-        results = self.engine.run(dtstart=datetime(2018, 12, 31, 23, 0, 0), dtuntil=datetime(2019, 1, 1, 1, 0, 0), interval='5min')
-        self.storage.save_items(results)
-
-        results = self.engine.run(dtstart=datetime(2019, 1, 1, 1, 0, 0), dtuntil=datetime(2019, 1, 1, 4, 0, 0), interval='10min')
-        self.storage.save_items(results)
-
-        results = self.engine.run(dtstart=datetime(2019, 1, 1, 4, 0, 0), dtuntil=datetime(2019, 1, 1, 9, 0, 0), interval='30min')
-        self.storage.save_items(results)
+        return [
+            AnimationStep(dtstart=datetime(2018, 12, 31, 15, 0, 0), dtuntil=datetime(2018, 12, 31, 20, 0, 0), interval='30min'),
+            AnimationStep(dtstart=datetime(2018, 12, 31, 20, 0, 0), dtuntil=datetime(2018, 12, 31, 23, 0, 0), interval='10min'),
+            AnimationStep(dtstart=datetime(2018, 12, 31, 23, 0, 0), dtuntil=datetime(2019, 1, 1, 1, 0, 0), interval='5min'),
+            AnimationStep(dtstart=datetime(2019, 1, 1, 1, 0, 0), dtuntil=datetime(2019, 1, 1, 4, 0, 0), interval='10min'),
+            AnimationStep(dtstart=datetime(2019, 1, 1, 4, 0, 0), dtuntil=datetime(2019, 1, 1, 9, 0, 0), interval='30min'),
+        ]
 
     def cdc_maps(self):
+        """
+        DWD CDC, temperatur-sonne-and-niederschlag-karten
+        """
         logger.info('Running scenario cdc_maps')
-
-        # CDC, temperatur-sonne-and-niederschlag-karten
-        results = self.engine.run(dtstart=datetime(2018, 3, 6, 5, 0, 0), dtuntil=datetime(2018, 3, 10, 23, 59, 59), interval='hourly')
+        return AnimationStep(dtstart=datetime(2018, 3, 6, 5, 0, 0), dtuntil=datetime(2018, 3, 10, 23, 59, 59), interval='hourly')
 
         # Short sequence, for debugging processes.
-        #results = self.engine.run(dtstart=datetime(2018, 3, 6, 5, 0, 0), dtuntil=datetime(2018, 3, 6, 6, 59, 59), interval='hourly')
-
-        self.storage.save_items(results)
+        return AnimationStep(dtstart=datetime(2018, 3, 6, 5, 0, 0), dtuntil=datetime(2018, 3, 6, 6, 59, 59), interval='hourly')
 
     def uba_ldi_dwd_maps(self):
+        """
+        Labor: Studio / UBA/LDI/DWD-Studio [dev!]
+        """
         logger.info('Running scenario uba_ldi_dwd_maps')
-
-        # Labor: Studio / UBA/LDI/DWD-Studio [dev!]
-        results = self.engine.run(dtstart=datetime(2018, 10, 6, 5, 0, 0), dtuntil=datetime(2018, 10, 10, 23, 59, 59), interval='hourly')
-
-        self.storage.save_items(results)
+        return AnimationStep(dtstart=datetime(2018, 10, 6, 5, 0, 0), dtuntil=datetime(2018, 10, 10, 23, 59, 59), interval='hourly')
 
     def ir_sensor_svg_pixmap(self):
         """
@@ -129,6 +112,4 @@ class AnimationScenario:
         dtuntil: 2018-08-14 03:16:36
         """
         logger.info('Running scenario ir_sensor_svg_pixmap')
-
-        results = self.engine.run(dtstart=datetime(2018, 8, 14, 3, 16, 0), dtuntil=datetime(2018, 8, 14, 3, 16, 36), interval='secondly')
-        self.storage.save_items(results)
+        return AnimationStep(dtstart=datetime(2018, 8, 14, 3, 16, 0), dtuntil=datetime(2018, 8, 14, 3, 16, 36), interval='secondly')

--- a/grafanimate/scenarios.py
+++ b/grafanimate/scenarios.py
@@ -16,7 +16,7 @@ The parameter `flavor` can has two values (defaulting to `window`):
 import logging
 from datetime import datetime
 
-from grafanimate.model import NavigationFlavor, AnimationStep
+from grafanimate.model import NavigationFlavor, AnimationStep, AnimationScenario
 
 logger = logging.getLogger(__name__)
 
@@ -30,11 +30,17 @@ def playdemo():
         grafanimate --grafana-url=https://play.grafana.org/ --dashboard-uid=000000012 --scenario=playdemo
     """
     logger.info('Running scenario playdemo')
-    return AnimationStep(
-        dtstart=datetime(2021, 11, 14, 2, 0, 0),
-        dtuntil=datetime(2021, 11, 14, 4, 16, 36),
-        interval='5min',
-        flavor=NavigationFlavor.EXPAND)
+    return AnimationScenario(
+        grafana_url="https://play.grafana.org/",
+        dashboard_uid="000000012",
+        steps=[
+            AnimationStep(
+                dtstart=datetime(2021, 11, 14, 2, 0, 0),
+                dtuntil=datetime(2021, 11, 14, 4, 16, 36),
+                interval='5min',
+                flavor=NavigationFlavor.EXPAND)
+        ]
+    )
 
 
 def ldi_all():

--- a/grafanimate/scenarios.py
+++ b/grafanimate/scenarios.py
@@ -1,6 +1,18 @@
 #  -*- coding: utf-8 -*-
 # (c) 2018-2021 Andreas Motl <andreas@hiveeyes.org>
 # License: GNU Affero General Public License, Version 3
+"""
+Run different animation scenarios/sequences.
+
+As the ad-hoc interface is not finished yet,
+this is all we got. Enjoy!
+
+The parameters `dtstart`, `dtuntil` and `interval` should explain themselves.
+
+The parameter `flavor` can has two values (defaulting to `window`):
+- "window" will slide a window through the defined time range
+- "expand" will use a fixed start time and stepwise expand the end time
+"""
 import logging
 from datetime import datetime
 
@@ -9,107 +21,131 @@ from grafanimate.model import NavigationFlavor, AnimationStep
 logger = logging.getLogger(__name__)
 
 
-class BuiltinScenarios:
+def playdemo():
     """
-    Run different animation scenarios/sequences.
+    Run demo on `play.grafana.org`.
 
-    As the ad-hoc interface is not finished yet,
-    this is all we got. Enjoy!
+    Example::
 
-    The parameters `dtstart`, `dtuntil` and `interval` should explain themselves.
-
-    The parameter `flavor` can has two values (defaulting to `window`):
-    - "window" will slide a window through the defined time range
-    - "expand" will use a fixed start time and stepwise expand the end time
+        grafanimate --grafana-url=https://play.grafana.org/ --dashboard-uid=000000012 --scenario=playdemo
     """
+    logger.info('Running scenario playdemo')
+    return AnimationStep(
+        dtstart=datetime(2021, 11, 14, 2, 0, 0),
+        dtuntil=datetime(2021, 11, 14, 4, 16, 36),
+        interval='5min',
+        flavor=NavigationFlavor.EXPAND)
 
-    def playdemo(self):
-        """
-        Run demo on `play.grafana.org`.
 
-        Example::
+def ldi_all():
+    """
+    Luftdaten.info, all
+    """
+    logger.info('Running scenario ldi_all')
 
-            grafanimate --grafana-url=https://play.grafana.org/ --dashboard-uid=000000012 --scenario=playdemo
-        """
-        logger.info('Running scenario playdemo')
-        return AnimationStep(dtstart=datetime(2021, 11, 14, 2, 0, 0), dtuntil=datetime(2021, 11, 14, 4, 16, 36), interval='5min', flavor=NavigationFlavor.EXPAND)
+    return [
 
-    def ldi_all(self):
-        """
-        Luftdaten.info, all
-        """
-        logger.info('Running scenario ldi_all')
+        # LDI, ramp-up
+        AnimationStep(
+            dtstart=datetime(2015, 10, 1),
+            dtuntil=datetime(2017, 1, 1),
+            interval='monthly'),
 
-        return [
+        # LDI, growth
+        AnimationStep(
+            dtstart=datetime(2017, 1, 1),
+            dtuntil=datetime.now(),
+            interval='weekly'),
 
-            # LDI, ramp-up
-            AnimationStep(dtstart=datetime(2015, 10, 1), dtuntil=datetime(2017, 1, 1), interval='monthly'),
+    ]
 
-            # LDI, growth
-            AnimationStep(dtstart=datetime(2017, 1, 1), dtuntil=datetime.now(), interval='weekly'),
 
-        ]
+def ldi_with_gaps():
+    """
+    Luftdaten.info, growth
+    """
+    logger.info('Running scenario ldi_with_gaps')
 
-    def ldi_with_gaps(self):
-        """
-        Luftdaten.info, growth
-        """
-        logger.info('Running scenario ldi_with_gaps')
+    return [
 
-        return [
+        # LDI, ramp-up
+        AnimationStep(
+            dtstart=datetime(2015, 10, 1),
+            dtuntil=datetime(2017, 1, 1),
+            interval='monthly'),
 
-            # LDI, ramp-up
-            AnimationStep(dtstart=datetime(2015, 10, 1), dtuntil=datetime(2017, 1, 1), interval='monthly'),
+        # LDI, growth, with gap at 2018-04-29 - 2018-12-20
+        # TODO: Detect empty data from datasource through Grafana Sidecar and skip respective images.
+        AnimationStep(
+            dtstart=datetime(2017, 1, 1),
+            dtuntil=datetime(2018, 6, 5),
+            interval='weekly'),
 
-            # LDI, growth, with gap at 2018-04-29 - 2018-12-20
-            # TODO: Detect empty data from datasource through Grafana Sidecar and skip respective images.
-            AnimationStep(dtstart=datetime(2017, 1, 1), dtuntil=datetime(2018, 6, 5), interval='weekly'),
+        # LDI, until now
+        AnimationStep(
+            dtstart=datetime(2018, 12, 20),
+            dtuntil=datetime.now(),
+            interval='weekly'),
+    ]
 
-            # LDI, until now
-            AnimationStep(dtstart=datetime(2018, 12, 20), dtuntil=datetime.now(), interval='weekly'),
-        ]
 
-    def ldi_nye_2017_2018(self):
-        """
-        LDI, New Year's Eve 2018
-        """
-        logger.info('Running scenario ldi_nye_2017_2018')
-        return AnimationStep(dtstart=datetime(2017, 12, 31, 21, 0, 0), dtuntil=datetime(2018, 1, 1, 4, 0, 0), interval='10min')
+def ldi_nye_2017_2018():
+    """
+    LDI, New Year's Eve 2018
+    """
+    logger.info('Running scenario ldi_nye_2017_2018')
+    return AnimationStep(
+        dtstart=datetime(2017, 12, 31, 21, 0, 0),
+        dtuntil=datetime(2018, 1, 1, 4, 0, 0),
+        interval='10min')
 
-    def ldi_nye_2018_2019(self):
-        """
-        LDI, New Year's Eve 2018/2019
-        """
-        logger.info('Running scenario ldi_nye_2018_2019')
-        return [
-            AnimationStep(dtstart=datetime(2018, 12, 31, 15, 0, 0), dtuntil=datetime(2018, 12, 31, 20, 0, 0), interval='30min'),
-            AnimationStep(dtstart=datetime(2018, 12, 31, 20, 0, 0), dtuntil=datetime(2018, 12, 31, 23, 0, 0), interval='10min'),
-            AnimationStep(dtstart=datetime(2018, 12, 31, 23, 0, 0), dtuntil=datetime(2019, 1, 1, 1, 0, 0), interval='5min'),
-            AnimationStep(dtstart=datetime(2019, 1, 1, 1, 0, 0), dtuntil=datetime(2019, 1, 1, 4, 0, 0), interval='10min'),
-            AnimationStep(dtstart=datetime(2019, 1, 1, 4, 0, 0), dtuntil=datetime(2019, 1, 1, 9, 0, 0), interval='30min'),
-        ]
 
-    def cdc_maps(self):
-        """
-        DWD CDC, temperatur-sonne-and-niederschlag-karten
-        """
-        logger.info('Running scenario cdc_maps')
-        return AnimationStep(dtstart=datetime(2018, 3, 6, 5, 0, 0), dtuntil=datetime(2018, 3, 10, 23, 59, 59), interval='hourly')
+def ldi_nye_2018_2019():
+    """
+    LDI, New Year's Eve 2018/2019
+    """
+    logger.info('Running scenario ldi_nye_2018_2019')
+    return [
+        AnimationStep(dtstart=datetime(2018, 12, 31, 15, 0, 0), dtuntil=datetime(2018, 12, 31, 20, 0, 0), interval='30min'),
+        AnimationStep(dtstart=datetime(2018, 12, 31, 20, 0, 0), dtuntil=datetime(2018, 12, 31, 23, 0, 0), interval='10min'),
+        AnimationStep(dtstart=datetime(2018, 12, 31, 23, 0, 0), dtuntil=datetime(2019, 1, 1, 1, 0, 0), interval='5min'),
+        AnimationStep(dtstart=datetime(2019, 1, 1, 1, 0, 0), dtuntil=datetime(2019, 1, 1, 4, 0, 0), interval='10min'),
+        AnimationStep(dtstart=datetime(2019, 1, 1, 4, 0, 0), dtuntil=datetime(2019, 1, 1, 9, 0, 0), interval='30min'),
+    ]
 
-        # Short sequence, for debugging processes.
-        return AnimationStep(dtstart=datetime(2018, 3, 6, 5, 0, 0), dtuntil=datetime(2018, 3, 6, 6, 59, 59), interval='hourly')
 
-    def uba_ldi_dwd_maps(self):
-        """
-        Labor: Studio / UBA/LDI/DWD-Studio [dev!]
-        """
-        logger.info('Running scenario uba_ldi_dwd_maps')
-        return AnimationStep(dtstart=datetime(2018, 10, 6, 5, 0, 0), dtuntil=datetime(2018, 10, 10, 23, 59, 59), interval='hourly')
+def cdc_maps():
+    """
+    DWD CDC, temperatur-sonne-and-niederschlag-karten
+    """
+    logger.info('Running scenario cdc_maps')
+    return AnimationStep(
+        dtstart=datetime(2018, 3, 6, 5, 0, 0),
+        dtuntil=datetime(2018, 3, 10, 23, 59, 59),
+        interval='hourly')
 
-    def ir_sensor_svg_pixmap(self):
-        """
-        dtstart: 2018-08-14 03:16:00
-        dtuntil: 2018-08-14 03:16:36
-        """
-        logger.info('Running scenario ir_sensor_svg_pixmap')
-        return AnimationStep(dtstart=datetime(2018, 8, 14, 3, 16, 0), dtuntil=datetime(2018, 8, 14, 3, 16, 36), interval='secondly')
+    # Short sequence, for debugging processes.
+    #return AnimationStep(dtstart=datetime(2018, 3, 6, 5, 0, 0), dtuntil=datetime(2018, 3, 6, 6, 59, 59), interval='hourly')
+
+
+def uba_ldi_dwd_maps():
+    """
+    Labor: Studio / UBA/LDI/DWD-Studio [dev!]
+    """
+    logger.info('Running scenario uba_ldi_dwd_maps')
+    return AnimationStep(
+        dtstart=datetime(2018, 10, 6, 5, 0, 0),
+        dtuntil=datetime(2018, 10, 10, 23, 59, 59),
+        interval='hourly')
+
+
+def ir_sensor_svg_pixmap():
+    """
+    dtstart: 2018-08-14 03:16:00
+    dtuntil: 2018-08-14 03:16:36
+    """
+    logger.info('Running scenario ir_sensor_svg_pixmap')
+    return AnimationStep(
+        dtstart=datetime(2018, 8, 14, 3, 16, 0),
+        dtuntil=datetime(2018, 8, 14, 3, 16, 36),
+        interval='secondly')

--- a/grafanimate/util.py
+++ b/grafanimate/util.py
@@ -6,6 +6,8 @@ import os
 import sys
 import socket
 import logging
+from pathlib import Path
+
 from munch import munchify
 from contextlib import closing
 from unidecode import unidecode
@@ -136,3 +138,24 @@ def as_list(seq):
         return list(seq)
     else:
         return [seq]
+
+
+def load_module(name: str, path: str):
+    """
+    Import Python module from file.
+    """
+
+    # Use absolute path.
+    modulefile = Path(path).absolute()
+
+    # Import module.
+    # https://stackoverflow.com/a/67692
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(name, modulefile)
+    if spec is None:
+        raise FileNotFoundError(f"Unable to find module file {modulefile}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    return mod

--- a/grafanimate/util.py
+++ b/grafanimate/util.py
@@ -117,3 +117,22 @@ def asbool(obj):
         else:
             raise ValueError("String is not true/false: %r" % obj)
     return bool(obj)
+
+
+def is_sequence(seq):
+    # From `numpy.distutils.misc_util`
+    if isinstance(seq, str):
+        return False
+    try:
+        len(seq)
+    except Exception:
+        return False
+    return True
+
+
+def as_list(seq):
+    # From `numpy.distutils.misc_util`
+    if is_sequence(seq):
+        return list(seq)
+    else:
+        return [seq]

--- a/grafanimate/util.py
+++ b/grafanimate/util.py
@@ -140,7 +140,7 @@ def as_list(seq):
         return [seq]
 
 
-def load_module(name: str, path: str):
+def import_module(name: str, path: str):
     """
     Import Python module from file.
     """


### PR DESCRIPTION
Hi.

This patch finally introduces a data model for defining animation-scenarios and -steps. This yields the following features:

- Scenarios can be loaded from arbitrary Python modules or files. For example, you can use `grafanimate --scenario=acme.scenarios:foobar` to load scenario data from the `foobar` variable within the `acme.scenarios` module. You can also address arbitrary files, by using an invocation like `--scenario=/path/to/acme/scenarios.py:foobar`.
- The `grafana-url` and `dashboard-uid` parameters can optionally be defined within the scenario description. For an example, please have a look at [`scenarios.py#L34-L35`](https://github.com/panodata/grafanimate/blob/e57044ce6b57c7d275d9624017e808fac9950c65/grafanimate/scenarios.py#L34-L35). When using the built-in scenario `playdemo`, it essentially brings the invocation down to `grafanimate --scenario=playdemo`.

With kind regards,
Andreas.
