### PR TITLE
When parsing timestamps, allow ISO8801/RFC3339 and Epoch time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ in progress
 - Optionally define ``grafana_url`` and ``dashboard_uid`` within scenario file.
   Corresponding command line parameters ``--grafana-url`` and ``--dashboard-uid``
   still take preference.
+- When parsing timestamps, allow ISO8801/RFC3339 and Epoch time (``dtstart`` and ``dtuntil``)
 
 
 2019-02-04 0.5.5

--- a/grafanimate/model.py
+++ b/grafanimate/model.py
@@ -2,9 +2,12 @@
 # (c) 2021 Andreas Motl <andreas.motl@panodata.org>
 # License: GNU Affero General Public License, Version 3
 import dataclasses
+
+import dateutil.parser
+from dataclass_property import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import List, Optional
+from typing import List, Optional, Union
 
 
 class SequencingMode(Enum):
@@ -12,12 +15,38 @@ class SequencingMode(Enum):
     CUMULATIVE = "cumulative"
 
 
-@dataclasses.dataclass
+@dataclass
 class AnimationStep:
-    dtstart: datetime
-    dtuntil: datetime
     interval: str
     mode: Optional[SequencingMode] = SequencingMode.WINDOW
+    milliseconds: int = 0
+
+    @property
+    def dtstart(self) -> datetime:
+        return self._dtstart
+
+    @property
+    def dtuntil(self) -> datetime:
+        return self._dtuntil
+
+    @dtstart.setter
+    def dtstart(self, value: Union[datetime, str]):
+        self._dtstart = self.convert_timestamp(value)
+
+    @dtuntil.setter
+    def dtuntil(self, value: Union[datetime, str]):
+        self._dtuntil = self.convert_timestamp(value)
+
+    def convert_timestamp(self, value: Union[datetime, str]) -> datetime:
+        if isinstance(value, datetime):
+            pass
+        elif isinstance(value, int):
+            value = datetime.fromtimestamp(value)
+        elif isinstance(value, str):
+            value = dateutil.parser.parse(value)
+        else:
+            raise TypeError("Unknown data type for `dtstart` or `dtuntil` value: {} ({})".format(value, type(value)))
+        return value
 
 
 @dataclasses.dataclass

--- a/grafanimate/scenarios.py
+++ b/grafanimate/scenarios.py
@@ -30,15 +30,59 @@ def playdemo():
         grafanimate --grafana-url=https://play.grafana.org/ --dashboard-uid=000000012 --scenario=playdemo
     """
     logger.info('Running scenario playdemo')
+
     return AnimationScenario(
         grafana_url="https://play.grafana.org/",
         dashboard_uid="000000012",
         steps=[
             AnimationStep(
                 dtstart=datetime(2021, 11, 14, 2, 0, 0),
-                dtuntil=datetime(2021, 11, 14, 4, 16, 36),
+
+                # Produce video with reasonable duration.
+                # dtuntil=datetime(2021, 11, 14, 4, 16, 36),
+
+                # Produce very short video.
+                dtuntil=datetime(2021, 11, 14, 2, 16, 36),
+
                 interval='5min',
-                mode=SequencingMode.CUMULATIVE)
+                mode=SequencingMode.CUMULATIVE,
+            ),
+        ]
+    )
+
+
+def playdemo_advanced():
+    """
+    Run demo on `play.grafana.org`.
+
+    Example::
+
+        grafanimate --grafana-url=https://play.grafana.org/ --dashboard-uid=000000012 --scenario=playdemo_advanced
+    """
+    logger.info('Running scenario playdemo')
+
+    return AnimationScenario(
+        grafana_url="https://play.grafana.org/",
+        dashboard_uid="000000012",
+        steps=[
+            AnimationStep(
+                dtstart=datetime(2021, 11, 14, 2, 0, 0),
+                dtuntil=datetime(2021, 11, 14, 2, 16, 36),
+                interval='5min',
+                mode=SequencingMode.CUMULATIVE,
+            ),
+            AnimationStep(
+                dtstart="2021-11-15T02:12:05Z",
+                dtuntil="2021-11-15T02:37:36Z",
+                interval='5min',
+                mode=SequencingMode.CUMULATIVE,
+            ),
+            AnimationStep(
+                dtstart=1637091011,
+                dtuntil=1637091911,
+                interval='5min',
+                mode=SequencingMode.CUMULATIVE,
+            ),
         ]
     )
 

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ requires = [
     'tqdm>=4,<5',
     'unidecode>=1,<2',
     'furl>=2,<3',
+    'dataclass-property>=1,<2',
 
     # Grafana control and animation
     'where>=1,<2',


### PR DESCRIPTION
Hi there,

@msweef asked at [1] for another detail:

> Start- und Endtime in Unix Epoch oder sogar gemischt.

this patch implements this feature. The built-in `scenarios.py` outlines what is possible now:

https://github.com/panodata/grafanimate/blob/7efec10c2eccf26557bfcc25b38dbc311bccf086/grafanimate/scenarios.py#L64-L87

With kind regards,
Andreas.

[1] https://community.hiveeyes.org/t/improving-time-range-control-for-grafanimate/1783/2

----

P.S.: Within this example, you will also recognize another two new features coming from other patches:
  1. Choosing `SequencingMode.CUMULATIVE` was unlocked by #7 and 62541a9.
  2. Making it possible to put `grafana_url` and `dashboard_uid` into the scenario description itself was unlocked by #8.
