### PR TITLE
Enable support for relative timestamps with months and years

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ in progress
   parameters. Accepted are humanized values like outlined above (``2m30s``),
   combined with, e.g., ``stop=start+2m30s`` or ``start=-1h, stop=now``.
 - Add CI configuration for GHA
+- Enable support for relative timestamps with months and years, like ``1y3mo``.
 
 
 2021-11-17 0.6.0

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requires = [
     "marionette_driver>=3,<4",
     "python-dateutil>=2.7,<3",
     "datetime-interval==0.2",
-    "pytimeparse2>=1.3,<2",
+    "pytimeparse2>=1.4,<2",
 ]
 
 extras = {

--- a/tests/test_timeutil.py
+++ b/tests/test_timeutil.py
@@ -114,7 +114,6 @@ def test_freq_delta_pytimeparse():
     assert recurrence.interval == 7
     assert recurrence.duration == relativedelta(days=+7, seconds=-1)
 
-    """
     recurrence = get_freq_delta("1mo")
     assert recurrence.frequency == MONTHLY
     assert recurrence.interval == 1
@@ -124,4 +123,8 @@ def test_freq_delta_pytimeparse():
     assert recurrence.frequency == YEARLY
     assert recurrence.interval == 1
     assert recurrence.duration == relativedelta(years=+1, seconds=-1)
-    """
+
+    recurrence = get_freq_delta("3 years 5 months")
+    assert recurrence.frequency == YEARLY
+    assert recurrence.interval == 3
+    assert recurrence.duration == relativedelta(years=+3, months=+5, seconds=-1)


### PR DESCRIPTION
Hi,

with a patch to the `pytimeparse2` library at https://github.com/onegreyonewhite/pytimeparse2/pull/1 being accepted by @onegreyonewhite (thanks a stack!), `grafanimate` now also supports calculating with years and months when obtaining relative timestamps, like `1y3mo` and `3 years 5 months`.

With kind regards,
Andreas.

