### PR TITLE
Avoid ffmpeg 'height not divisible by 2' errors

### DIFF
--- a/grafanimate/grafana.py
+++ b/grafanimate/grafana.py
@@ -34,7 +34,6 @@ class GrafanaWrapper(FirefoxMarionetteBase):
         """
         log.info("Starting Grafana at {}".format(self.baseurl))
 
-        self.fix_window_size()
         self.navigate(self.baseurl)
 
     def navigate(self, url):
@@ -51,25 +50,6 @@ class GrafanaWrapper(FirefoxMarionetteBase):
             with resource_stream("grafanimate", jsfile) as f:
                 javascript = f.read().decode("utf-8")
                 self.run_javascript(javascript)
-
-    def fix_window_size(self):
-        """
-        Work around FFmpeg errors like::
-
-          Input #0, image2, from './var/spool/DLOlE_Rmz/DLOlE_Rmz_*.png':
-            Duration: 00:00:28.75, start: 0.000000, bitrate: N/A
-              Stream #0:0: Video: png, rgba(pc), 1497x483, 4 fps, 4 tbr, 4 tbn, 4 tbc
-
-        [libx264 @ 0x7fcf0c001200] width not divisible by 2 (1497x483)
-
-        [libx264 @ 0x7fa917001200] height not divisible by 2 (1348x823)
-        """
-        window_size = self.get_window_rect()
-        if window_size["width"] % 2:
-            window_size["width"] -= 1
-        if window_size["height"] % 2:
-            window_size["height"] -= 1
-        self.set_window_size(window_size["width"], window_size["height"])
 
     def wait_for_grafana(self):
         """

--- a/grafanimate/postprocessing.py
+++ b/grafanimate/postprocessing.py
@@ -26,7 +26,8 @@ class MediaProducer:
         # command = "ffmpeg -framerate 4 -pattern_type glob -i '{}' -c:v libx264 -vf 'fps=25,format=yuv420p,drawtext=text=Produced with Grafana and grafanimate:fontsize=11:x=w-tw-30:y=h-th-10:fontcolor=lightgrey:fontfile=/Library/Fonts/Arial.ttf' '{}' -y".format(source, target)
 
         # TODO: Expose `-framerate` and `fps` values.
-        command = f"ffmpeg -framerate {self.options.video_framerate} -pattern_type glob -i '{source}' -c:v libx264 -vf 'fps={self.options.video_fps},format=yuv420p' '{target}' -y"
+        # use the `pad` option to avoid ffmpeg errors like 'height not divisible by 2'
+        command = f"ffmpeg -framerate {self.options.video_framerate} -pattern_type glob -i '{source}' -c:v libx264 -vf 'pad=ceil(iw/2)*2:ceil(ih/2)*2,fps={self.options.video_fps},format=yuv420p' '{target}' -y"
         logger.info("Rendering video: {}".format(target))
         logger.debug(command)
         os.system(command)


### PR DESCRIPTION
Avoid errors in every case by padding the input to ffmpeg rather than trying to do the same when creating the firefox window, which doesn't always work.