### PR TITLE
Fix GH actions: Revert to ubuntu-20.04 image for python-3.6 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 5
       matrix:


### PR DESCRIPTION
ubuntu-latest has been changed from ubuntu-20.04 to ubuntu-22.04

Ubuntu-22.04 no longer supports python 3.6 https://github.com/actions/setup-python/issues/543#issuecomment-1319863102

Either revert back to ubuntu-20.04 in this PR, or PR #23 to drop python 3.6.
I'd prefer removing python 3.6 to move forwards?