### PR TITLE
Fix GH actions: python 3.6 not supported in ubuntu-22.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10']
 
     name: Python ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
 
     name: Python ${{ matrix.python-version }}
     steps:


### PR DESCRIPTION
Ubuntu-22.04 no longer supports python 3.6 https://github.com/actions/setup-python/issues/543#issuecomment-1319863102

Remove python 3.6 with this PR, or revert to ubuntu-20.04 in PR #22

I'd prefer removing python 3.6 to move forwards?