### PR TITLE
README.rst syntax highlight

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ in its postprocessing subsystem.
 grafanimate
 ===========
 
-::
+.. code:: sh
 
     pip install grafanimate
 
@@ -114,7 +114,9 @@ A scenario definition:
     )
 
 
-In order to run a built-in scenario, invoke::
+In order to run a built-in scenario, invoke:
+
+.. code:: sh
 
     grafanimate --scenario=playdemo --output=./animations
 
@@ -131,7 +133,9 @@ Help
 ====
 
 For getting a detailed and descriptive overview about all available command
-line options, please invoke::
+line options, please invoke:
+
+.. code:: sh
 
     grafanimate --help
 
@@ -141,7 +145,7 @@ Examples
 Examples for scenario mode. Script your animations in file ``scenarios.py`` or
 any other Python module or file.
 
-::
+.. code:: sh
 
     # Use freely accessible `play.grafana.org` for demo purposes.
     grafanimate --scenario=playdemo --output=./animations
@@ -162,7 +166,7 @@ Usage in Containers
 You can use ``grafanimate`` with Docker and Podman. An OCI image is published
 to ``ghcr.io/panodata/grafanimate``.
 
-::
+.. code:: sh
 
     docker run --rm -it --volume=$(PWD)/animations:/animations ghcr.io/panodata/grafanimate \
         --header-layout=no-chrome \
@@ -289,7 +293,7 @@ to implement more complex animations on top of Grafana.
 Development
 ***********
 
-::
+.. code:: sh
 
     # Acquire sources.
     git clone https://github.com/panodata/grafanimate

--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,9 @@ multiple scenarios.
 Synopsis
 ========
 
-A scenario definition::
+A scenario definition:
+
+.. code:: python
 
     AnimationScenario(
         grafana_url="https://play.grafana.org/",
@@ -259,7 +261,9 @@ in a more general way yet. Challenge accepted!
 
 Time warp
 =========
-At this programs' core is the code to `set time range in Grafana`_::
+At this programs' core is the code to `set time range in Grafana`_:
+
+.. code:: javascript
 
     timeSrv = angular.element('grafana-app').injector().get('timeSrv');
     timeSrv.setTime({from: "2015-10-01", to: "2018-12-31"});


### PR DESCRIPTION
My first time writing .rst, I always used markdown.

Can be previewed here: https://github.com/intermittentnrg/grafanimate/blob/readme-python/README.rst

python and javascript highlighting is nice. Not sure shell highlighting is better.

Note that `.. note::` doesn't seem to be working in github, and I didn't get nested highlighting to work in that block.